### PR TITLE
no-task: fix unsupported typing

### DIFF
--- a/sheets/handlers/statistics.py
+++ b/sheets/handlers/statistics.py
@@ -56,7 +56,7 @@ def get_user_statistics_for_today(
 
 def get_statistic_for_today(
         filter_by_section_id: Optional[str] = None,
-) -> dict[str, dict[list[tuple[str, list] | dict[str, str | list]]]]:
+) -> dict[str, dict[list[Union[tuple[str, list], dict[str, Union[str, list]]]]]]:
     """
     TODO
 

--- a/views/handlers/statistics.py
+++ b/views/handlers/statistics.py
@@ -1,3 +1,5 @@
+from ctypes import Union
+
 from telebot.types import Message, ReplyKeyboardMarkup, InlineKeyboardButton
 
 from settings import settings, telegram as tele
@@ -195,7 +197,7 @@ class StatisticsHandler:
 
     @staticmethod
     def build_result_message_general_values_day(
-            data: dict[str, dict[list[tuple[str, list] | dict[str, str | list]]]]
+            data: dict[str, dict[list[Union[tuple[str, list], dict[str, Union[str, list]]]]]]
     ) -> str:
         messages_batch = ['\U0001F4C5 - СТАТИСТИКА ЗА ДЕНЬ']
 


### PR DESCRIPTION
No-task

Replace ` | ` with `Union[]` in views and scripts